### PR TITLE
Avoid expensive memory writes when not necessary

### DIFF
--- a/source/httpd-ack.c
+++ b/source/httpd-ack.c
@@ -305,8 +305,11 @@ void send_track(http_state_t *hs, int ipbintoc, int session, int track, int secp
       sector_read = sector_end - sector;
     }
 
-    // poison the entire malloc
-    memset(nocache, 'Q', SECTOR_BUFFER);
+    data_size = (sector_size * sector_read);
+
+    // poison the malloc when reading raw sectors
+    if (sector_size == 2352)
+      memset(nocache, 'Q', data_size);
     attempt = 0;
 
     do {
@@ -324,8 +327,6 @@ void send_track(http_state_t *hs, int ipbintoc, int session, int track, int secp
         if(abort)
           goto send_track_out;
     }
-
-    data_size = (sector_size * sector_read);
 
     // syscall method of getting sub channel data
     if(sub == SUB_SYSCALL) {


### PR DESCRIPTION
This change pretty significantly speeds up the dump process as this memset is one of the more expensive operations that eats a lot of time between gdrom read and network send. In the original code it poisons the entire malloc even though actual data size tends to be much smaller (default being 16 sectors while the entire malloc is 128). Limiting it to just the region being used provides a big speedup.

It also seems unnecessary entirely when not reading raw sectors, i.e. 2352 byte sectors, as any memory inconsistencies only manifest in the subheader sections. I don't really understand why this is tbh, but it's a nice additional boost when dumping as 2048 byte sector iso.